### PR TITLE
update to 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.12-SNAPSHOT'
+    id 'fabric-loom' version '1.1-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.3
-loader_version=0.14.11
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
+loader_version=0.14.19
 
 #Fabric api
-fabric_version=0.69.1+1.19.3
+fabric_version=0.80.0+1.19.4
 
 # Mod Properties
-mod_version=1.19.3-01
+mod_version=1.19.4-01
 maven_group=fzzyhmstrs
 archives_base_name=structurized_reborn
 

--- a/src/main/java/fzzyhmstrs/structurized_reborn/impl/FabricStructurePoolRegistry.java
+++ b/src/main/java/fzzyhmstrs/structurized_reborn/impl/FabricStructurePoolRegistry.java
@@ -17,8 +17,8 @@ import net.minecraft.util.Pair;
 import net.minecraft.util.math.random.LocalRandom;
 import net.minecraft.world.gen.feature.PlacedFeature;
 import org.apache.commons.lang3.tuple.Triple;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.*;
 
 public class FabricStructurePoolRegistry {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "structurized-reborn",
-  "version": "1.19.3-01",
+  "version": "${version}",
   "name": "Structurized Reborn",
   "description":"Simple library for registering new structures into villages. Credit to draylar for the original structurized: https://github.com/omega-mc/structurized/tree/1.18",
   "authors": [
@@ -13,6 +13,6 @@
   ],
   "accessWidener": "structurized.accesswidener",
   "depends": {
-    "minecraft": "1.19.3"
+    "minecraft": "1.19.4"
   }
 }


### PR DESCRIPTION
Updated minimum version to 1.19.4
If maybe in fabric.mod.json, make it so it goes from 1.19.3 and up (`>=1.19.3` or `1.19.x`). Or make a version for every release.
Don't have a good branch to request to. move it to a different one if you can.
